### PR TITLE
When name is empty, return false

### DIFF
--- a/src/ClydeUpload.php
+++ b/src/ClydeUpload.php
@@ -83,7 +83,7 @@ class ClydeUpload
      */
     public function exists($filename)
     {
-        return $this->disk->exists($this->buildPath($filename));
+        return empty($filename) ? false : $this->disk->exists($this->buildPath($filename));
     }
 
     /**


### PR DESCRIPTION
Method exists does not provide empty filename and checks instead of the file folder
